### PR TITLE
Make property type required in if/then/else conditions, as in case of…

### DIFF
--- a/field-type.schema.json
+++ b/field-type.schema.json
@@ -134,7 +134,8 @@
 					"type": {
 						"const": "Text"
 					}
-				}
+				},
+        "required": ["type"]
 			},
 			"then": {
 				"properties": {
@@ -174,7 +175,8 @@
 					"type": {
 						"const": "Textarea"
 					}
-				}
+				},
+        "required": ["type"]
 			},
 			"then": {
 				"properties": {
@@ -212,7 +214,8 @@
 					"type": {
 						"const": "Category"
 					}
-				}
+				},
+        "required": ["type"]
 			},
 			"then": {
 				"properties": {
@@ -255,7 +258,8 @@
 					"type": {
 						"const": "Checkbox"
 					}
-				}
+				},
+        "required": ["type"]
 			},
 			"then": {
 				"properties": {
@@ -313,7 +317,8 @@
 					"type": {
 						"const": "Collection"
 					}
-				}
+				},
+        "required": ["type"]
 			},
 			"then": {
 				"properties": {
@@ -398,7 +403,8 @@
 					"type": {
 						"const": "Color"
 					}
-				}
+				},
+        "required": ["type"]
 			},
 			"then": {
 				"properties": {
@@ -426,7 +432,8 @@
 					"type": {
 						"const": "DateTime"
 					}
-				}
+				},
+        "required": ["type"]
 			},
 			"then": {
 				"properties": {
@@ -478,7 +485,8 @@
 					"type": {
 						"const": "Email"
 					}
-				}
+				},
+        "required": ["type"]
 			},
 			"then": {
 				"properties": {
@@ -507,7 +515,8 @@
 					"type": {
 						"const": "File"
 					}
-				}
+				},
+        "required": ["type"]
 			},
 			"then": {
 				"properties": {
@@ -594,7 +603,8 @@
 					"type": {
 						"const": "Folder"
 					}
-				}
+				},
+        "required": ["type"]
 			},
 			"then": {
 				"properties": {
@@ -626,7 +636,8 @@
 					"type": {
 						"const": "Json"
 					}
-				}
+				},
+        "required": ["type"]
 			},
 			"then": {
 				"properties": {
@@ -663,7 +674,8 @@
 					"type": {
 						"const": "Language"
 					}
-				}
+				},
+        "required": ["type"]
 			},
 			"then": {
 				"properties": {
@@ -688,7 +700,8 @@
 					"type": {
 						"const": "Linebreak"
 					}
-				}
+				},
+        "required": ["type"]
 			},
 			"then": {
 				"properties": {
@@ -705,7 +718,8 @@
 					"type": {
 						"const": "Link"
 					}
-				}
+				},
+        "required": ["type"]
 			},
 			"then": {
 				"properties": {
@@ -748,7 +762,8 @@
 					"type": {
 						"const": "Number"
 					}
-				}
+				},
+        "required": ["type"]
 			},
 			"then": {
 				"properties": {
@@ -799,7 +814,8 @@
 					"type": {
 						"const": "Palette"
 					}
-				}
+				},
+        "required": ["type"]
 			},
 			"then": {
 				"properties": {
@@ -818,7 +834,8 @@
 					"type": {
 						"const": "Password"
 					}
-				}
+				},
+        "required": ["type"]
 			},
 			"then": {
 				"properties": {
@@ -920,7 +937,8 @@
 					"type": {
 						"const": "Relation"
 					}
-				}
+				},
+        "required": ["type"]
 			},
 			"then": {
 				"properties": {
@@ -1049,7 +1067,8 @@
 					"type": {
 						"const": "Slug"
 					}
-				}
+				},
+        "required": ["type"]
 			},
 			"then": {
 				"properties": {
@@ -1102,7 +1121,8 @@
 					"type": {
 						"const": "Uuid"
 					}
-				}
+				},
+        "required": ["type"]
 			},
 			"then": {
 				"properties": {

--- a/field-type.schema.json
+++ b/field-type.schema.json
@@ -575,7 +575,8 @@
 					"type": {
 						"const": "FlexForm"
 					}
-				}
+				},
+        "required": ["type"]
 			},
 			"then": {
 				"properties": {
@@ -868,7 +869,8 @@
 					"type": {
 						"const": "Radio"
 					}
-				}
+				},
+        "required": ["type"]
 			},
 			"then": {
 				"properties": {
@@ -961,7 +963,8 @@
 					"type": {
 						"const": "Select"
 					}
-				}
+				},
+        "required": ["type"]
 			},
 			"then": {
 				"properties": {
@@ -1037,7 +1040,7 @@
 						}
 					}
 				},
-				"required": ["renderType"]
+				"required": ["renderType", "items"]
 			}
 		},
 		{


### PR DESCRIPTION
… undefined property type the then case will always be executed.

I think there is a misunderstanding regarding if/then/else in json schema.

Consider these examples:

```
"if": {
	"properties": {
	  "country": {"const": "select"}
	}
},
"then": {
	"properties": {
	  "thisWillAlwaysBeDefined": { type: string }
	}
}
```

It looks like THEN will only be executed if country == "select" but this is NOT true! As country is not a required field the if part will always evaluate to true and the then branch will be "executed".

To make the then branch active only if country equals "select" you have to require the country property:

```
"if": {
	"properties": {
		"country": {"const": "select"}
	},
	"required": ["country"]
},
"then": {
	"properties": {
		"onlyIfCountryDefinedAndValueIsSelect": { type: string }
	}
}
```

This is what I changed in the schema deinition to make it work like expected. Not sure if I catched all the cases but at first glance it looks way better than before ;-)

